### PR TITLE
Add lybniz to Math menu category

### DIFF
--- a/lybniz.desktop
+++ b/lybniz.desktop
@@ -81,5 +81,5 @@ Exec=lybniz
 Terminal=false
 StartupNotify=true
 Type=Application
-Categories=Education;
+Categories=Education;Math;
 Icon=lybniz


### PR DESCRIPTION
There is menu section, like Education/Math or Science/Math.
Also this change is found in gentoo ebuild for 1.3.2.